### PR TITLE
concurrency のロック待ちを `sync.Cond` に移行

### DIFF
--- a/simpledb/tx/concurrency/lock_table.go
+++ b/simpledb/tx/concurrency/lock_table.go
@@ -31,19 +31,15 @@ func (l *LockTable) SLock(blockID file.BlockID) error {
 	l.mux.Lock()
 	defer l.mux.Unlock()
 
-	timeoutChan := time.After(maxLockTime)
+	startTime := time.Now()
 	for {
-		select {
-		case <-timeoutChan:
+		if time.Since(startTime) > maxLockTime {
 			return ErrTimeout
-		default:
-			if !l.hasXLock(blockID) {
-				goto notlocked
-			}
+		} else if !l.hasXLock(blockID) {
+			break
 		}
-		l.cond.Wait()
+		l.waitWithTimeout(maxLockTime)
 	}
-notlocked:
 
 	l.locks[blockID]++
 	return nil
@@ -53,19 +49,15 @@ func (l *LockTable) XLock(blockID file.BlockID) error {
 	l.mux.Lock()
 	defer l.mux.Unlock()
 
-	timeoutChan := time.After(maxLockTime)
+	startTime := time.Now()
 	for {
-		select {
-		case <-timeoutChan:
+		if time.Since(startTime) > maxLockTime {
 			return ErrTimeout
-		default:
-			if !l.hasOtherSLocks(blockID) {
-				goto notlocked
-			}
+		} else if !l.hasOtherSLocks(blockID) {
+			break
 		}
-		l.cond.Wait()
+		l.waitWithTimeout(maxLockTime)
 	}
-notlocked:
 
 	l.locks[blockID] = -1
 	return nil
@@ -89,4 +81,19 @@ func (l *LockTable) hasXLock(blockID file.BlockID) bool {
 
 func (l *LockTable) hasOtherSLocks(blockID file.BlockID) bool {
 	return l.locks[blockID] > 1
+}
+
+// Java の `wait(MAX_TIME)` 相当を実現するために追加
+func (l *LockTable) waitWithTimeout(timeout time.Duration) {
+	timer := time.AfterFunc(timeout, func() {
+		l.mux.Lock()
+		defer l.mux.Unlock()
+		l.cond.Broadcast()
+	})
+	l.cond.Wait()
+
+	// NOTE: タイミング次第で `Stop()` 呼び出し前にすでに timer が動いてしまう可能性あり
+	// その場合 Broadcast が実行されてしまうが、その際に Wait があってもなくても
+	// 今の処理であればループでロック状態を確認しており特に問題はなさそうに見える
+	timer.Stop()
 }

--- a/simpledb/tx/concurrency_lock_test.go
+++ b/simpledb/tx/concurrency_lock_test.go
@@ -30,9 +30,12 @@ func TestConcurrencySLockTimeout(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		txA := tx.New(fm, lm, bm)
+		txA, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
-		err := txA.Pin(blk1)
+		err = txA.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -40,13 +43,17 @@ func TestConcurrencySLockTimeout(t *testing.T) {
 		_, err = txA.GetInt(blk1, 0)
 		if err != nil {
 			t.Logf("Tx A: %v, rollback", err)
-			txA.Rollback()
+			if err := txA.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx A: receive slock 1")
 		time.Sleep(12 * time.Second)
 
-		txA.Commit()
+		if err := txA.Commit(); err != nil {
+			panic(err)
+		}
 		t.Log("Tx A: commit")
 	}()
 
@@ -56,9 +63,12 @@ func TestConcurrencySLockTimeout(t *testing.T) {
 		// txA に先にロックをとってもらう
 		time.Sleep(1 * time.Second)
 
-		txB := tx.New(fm, lm, bm)
+		txB, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
-		err := txB.Pin(blk1)
+		err = txB.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -67,7 +77,9 @@ func TestConcurrencySLockTimeout(t *testing.T) {
 		if err != nil {
 			// Timeout でこちらの分岐に入ることが期待値
 			t.Logf("Tx B: %v, rollback", err)
-			txB.Rollback()
+			if err := txB.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Errorf("Tx B: Does not reach here")
@@ -95,9 +107,12 @@ func TestConcurrencyXLockTimeout(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		txA := tx.New(fm, lm, bm)
+		txA, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
-		err := txA.Pin(blk1)
+		err = txA.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -105,13 +120,17 @@ func TestConcurrencyXLockTimeout(t *testing.T) {
 		err = txA.SetInt(blk1, 0, 0, false)
 		if err != nil {
 			t.Logf("Tx A: %v, rollback", err)
-			txA.Rollback()
+			if err := txA.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx A: receive xlock 1")
 		time.Sleep(12 * time.Second)
 
-		txA.Commit()
+		if err := txA.Commit(); err != nil {
+			panic(err)
+		}
 		t.Log("Tx A: commit")
 	}()
 
@@ -121,9 +140,12 @@ func TestConcurrencyXLockTimeout(t *testing.T) {
 		// txA に先にロックをとってもらう
 		time.Sleep(1 * time.Second)
 
-		txB := tx.New(fm, lm, bm)
+		txB, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
-		err := txB.Pin(blk1)
+		err = txB.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -132,7 +154,9 @@ func TestConcurrencyXLockTimeout(t *testing.T) {
 		if err != nil {
 			// Timeout でこちらの分岐に入ることが期待値
 			t.Logf("Tx B: %v, rollback", err)
-			txB.Rollback()
+			if err := txB.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Errorf("Tx B: Does not reach here")

--- a/simpledb/tx/concurrency_lock_test.go
+++ b/simpledb/tx/concurrency_lock_test.go
@@ -1,0 +1,142 @@
+package tx_test
+
+import (
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"simpledb/file"
+	"simpledb/server"
+	"simpledb/tx"
+)
+
+func TestConcurrencySLockTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode, this takes long time for checking timeout.")
+	}
+
+	db, err := server.NewSimpleDB(path.Join(t.TempDir(), "concurrencytest"), 400, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fm := db.FileManager()
+	lm := db.LogManager()
+	bm := db.BufferManager()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		txA := tx.New(fm, lm, bm)
+		blk1 := file.NewBlockID("testfile", 1)
+		err := txA.Pin(blk1)
+		if err != nil {
+			panic(err)
+		}
+		t.Log("Tx A: request slock 1")
+		_, err = txA.GetInt(blk1, 0)
+		if err != nil {
+			t.Logf("Tx A: %v, rollback", err)
+			txA.Rollback()
+			return
+		}
+		t.Log("Tx A: receive slock 1")
+		time.Sleep(12 * time.Second)
+
+		txA.Commit()
+		t.Log("Tx A: commit")
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// txA に先にロックをとってもらう
+		time.Sleep(1 * time.Second)
+
+		txB := tx.New(fm, lm, bm)
+		blk1 := file.NewBlockID("testfile", 1)
+		err := txB.Pin(blk1)
+		if err != nil {
+			panic(err)
+		}
+		t.Log("Tx B: request xlock 1")
+		err = txB.SetInt(blk1, 0, 0, false)
+		if err != nil {
+			// Timeout でこちらの分岐に入ることが期待値
+			t.Logf("Tx B: %v, rollback", err)
+			txB.Rollback()
+			return
+		}
+		t.Errorf("Tx B: Does not reach here")
+	}()
+
+	wg.Wait()
+}
+
+func TestConcurrencyXLockTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode, this takes long time for checking timeout.")
+	}
+
+	db, err := server.NewSimpleDB(path.Join(t.TempDir(), "concurrencytest"), 400, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fm := db.FileManager()
+	lm := db.LogManager()
+	bm := db.BufferManager()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+
+		txA := tx.New(fm, lm, bm)
+		blk1 := file.NewBlockID("testfile", 1)
+		err := txA.Pin(blk1)
+		if err != nil {
+			panic(err)
+		}
+		t.Log("Tx A: request xlock 1")
+		err = txA.SetInt(blk1, 0, 0, false)
+		if err != nil {
+			t.Logf("Tx A: %v, rollback", err)
+			txA.Rollback()
+			return
+		}
+		t.Log("Tx A: receive xlock 1")
+		time.Sleep(12 * time.Second)
+
+		txA.Commit()
+		t.Log("Tx A: commit")
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		// txA に先にロックをとってもらう
+		time.Sleep(1 * time.Second)
+
+		txB := tx.New(fm, lm, bm)
+		blk1 := file.NewBlockID("testfile", 1)
+		err := txB.Pin(blk1)
+		if err != nil {
+			panic(err)
+		}
+		t.Log("Tx B: request slock 1")
+		_, err = txB.GetInt(blk1, 0)
+		if err != nil {
+			// Timeout でこちらの分岐に入ることが期待値
+			t.Logf("Tx B: %v, rollback", err)
+			txB.Rollback()
+			return
+		}
+		t.Errorf("Tx B: Does not reach here")
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
`TestConcurrency` の実行結果は 5.4.2 の説明通りに動くようになりました。 #4 

### before

```
$ go test -v -run TestConcurrency
=== RUN   TestConcurrency
new transaction: 1
new transaction: 2
new transaction: 3
    concurrency_test.go:80: Tx B: request xlock 2
    concurrency_test.go:87: Tx B: receive xlock 2
    concurrency_test.go:44: Tx A: request slock 1
    concurrency_test.go:51: Tx A: receive slock 1
    concurrency_test.go:118: Tx C: request xlock 1
    concurrency_test.go:90: Tx B: request slock 1
    concurrency_test.go:54: Tx A: request slock 2
    concurrency_test.go:121: Tx C: timeout error, rollback
    concurrency_test.go:97: Tx B: receive slock 1
transaction 1 rolled back
transaction 3 committed
    concurrency_test.go:57: Tx A: timeout error, rollback
    concurrency_test.go:99: Tx B: commit
transaction 2 rolled back
--- PASS: TestConcurrency (20.51s)
PASS
ok  	simpledb/tx	20.856s
```

### after

```
$ go test -v -run TestConcurrency
=== RUN   TestConcurrency
new transaction: 1
new transaction: 2
new transaction: 3
    concurrency_test.go:80: Tx B: request xlock 2
    concurrency_test.go:87: Tx B: receive xlock 2
    concurrency_test.go:44: Tx A: request slock 1
    concurrency_test.go:51: Tx A: receive slock 1
    concurrency_test.go:118: Tx C: request xlock 1
    concurrency_test.go:54: Tx A: request slock 2
    concurrency_test.go:90: Tx B: request slock 1
    concurrency_test.go:97: Tx B: receive slock 1
transaction 3 committed
    concurrency_test.go:99: Tx B: commit
    concurrency_test.go:61: Tx A: receive slock 2
transaction 2 committed
    concurrency_test.go:63: Tx A: commit
    concurrency_test.go:125: Tx C: receive xlock 1
    concurrency_test.go:127: Tx C: request slock 2
    concurrency_test.go:134: Tx C: receive slock 2
transaction 1 committed
    concurrency_test.go:136: Tx C: commit
--- PASS: TestConcurrency (2.01s)
PASS
ok  	simpledb/tx	2.382s
```