### PR TITLE
add golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version: '1.22'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: latest
+          version: v1.59
           working-directory: simpledb

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: simpledb

--- a/simpledb/.golangci.yml
+++ b/simpledb/.golangci.yml
@@ -1,0 +1,4 @@
+linters:
+  enable:
+    - gofmt
+    - goimports

--- a/simpledb/buffer/buffer.go
+++ b/simpledb/buffer/buffer.go
@@ -2,7 +2,6 @@ package buffer
 
 import (
 	"errors"
-
 	"simpledb/file"
 )
 

--- a/simpledb/file/file.go
+++ b/simpledb/file/file.go
@@ -199,8 +199,14 @@ func (fm *Manager) Append(filename string) (BlockID, error) {
 		return BlockID{}, fmt.Errorf("fm.openFile: %w", err)
 	}
 
-	f.Seek(int64(blk.Number)*int64(fm.blockSize), 0)
-	f.Write(b)
+	_, err = f.Seek(int64(blk.Number)*int64(fm.blockSize), 0)
+	if err != nil {
+		return BlockID{}, fmt.Errorf("f.Seek: %w", err)
+	}
+	_, err = f.Write(b)
+	if err != nil {
+		return BlockID{}, fmt.Errorf("f.Write: %w", err)
+	}
 
 	return blk, nil
 }

--- a/simpledb/file/file.go
+++ b/simpledb/file/file.go
@@ -3,6 +3,7 @@ package file
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -159,7 +160,7 @@ func (fm *Manager) Read(blk BlockID, p *Page) error {
 	}
 
 	_, err = f.Read(p.buffer)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return fmt.Errorf("f.Read: %w", err)
 	}
 

--- a/simpledb/log/log.go
+++ b/simpledb/log/log.go
@@ -85,7 +85,9 @@ func NewManager(fileManager *file.Manager, logFile string) (*Manager, error) {
 		}
 	} else {
 		lm.currentBlk = file.NewBlockID(logFile, logSize-1)
-		fileManager.Read(lm.currentBlk, logPage)
+		if err := fileManager.Read(lm.currentBlk, logPage); err != nil {
+			return nil, fmt.Errorf("fileManager.Read: %w", err)
+		}
 	}
 
 	return lm, nil
@@ -98,7 +100,9 @@ func (lm *Manager) appendNewBlock() (file.BlockID, error) {
 	}
 
 	lm.logPage.SetInt(0, int32(lm.fileManager.BlockSize()))
-	lm.fileManager.Write(blk, lm.logPage)
+	if err := lm.fileManager.Write(blk, lm.logPage); err != nil {
+		return file.BlockID{}, fmt.Errorf("fileManager.Write: %w", err)
+	}
 
 	return blk, nil
 }

--- a/simpledb/log/log_test.go
+++ b/simpledb/log/log_test.go
@@ -45,12 +45,18 @@ func TestLog(t *testing.T) {
 }
 
 func printLogRecords(logManager *log.Manager) string {
-	iter := logManager.Iterator()
+	iter, err := logManager.Iterator()
+	if err != nil {
+		panic(err)
+	}
 
 	res := ""
 	sentinel := 0
 	for iter.HasNext() {
-		rec := iter.Next()
+		rec, err := iter.Next()
+		if err != nil {
+			panic(err)
+		}
 		p := file.NewPageWith(rec)
 		s := p.GetString(0)
 		npos := file.MaxLength(int32(len(s)))

--- a/simpledb/metadata/catalog_test.go
+++ b/simpledb/metadata/catalog_test.go
@@ -14,8 +14,14 @@ func TestCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create simpledb: %v", err)
 	}
-	transaction := simpleDB.NewTx()
-	tableManager := metadata.NewTableManager(true, transaction)
+	transaction, err := simpleDB.NewTx()
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
+	tableManager, err := metadata.NewTableManager(true, transaction)
+	if err != nil {
+		t.Fatalf("failed to create table manager: %v", err)
+	}
 
 	schema := record.NewSchema()
 	schema.AddIntField("A")
@@ -88,5 +94,7 @@ func TestCatalog(t *testing.T) {
 		}
 	}
 	tableScan.Close()
-	transaction.Commit() // 紙面上だと書かれていないが、ないと実行が終わらないはず
+	if err := transaction.Commit(); err != nil { // 紙面上だと書かれていないが、ないと実行が終わらないはず
+		t.Fatalf("failed to commit: %v", err)
+	}
 }

--- a/simpledb/metadata/index_mgr.go
+++ b/simpledb/metadata/index_mgr.go
@@ -98,10 +98,18 @@ func (im *IndexManager) CreateIndex(indexName string, tableName string, fieldNam
 	}
 	defer ts.Close()
 
-	ts.Insert()
-	ts.SetString(indexCatalogFieldIndexName, indexName)
-	ts.SetString(indexCatalogFieldTableName, tableName)
-	ts.SetString(indexCatalogFieldFieldName, fieldName)
+	if err := ts.Insert(); err != nil {
+		return err
+	}
+	if err := ts.SetString(indexCatalogFieldIndexName, indexName); err != nil {
+		return err
+	}
+	if err := ts.SetString(indexCatalogFieldTableName, tableName); err != nil {
+		return err
+	}
+	if err := ts.SetString(indexCatalogFieldFieldName, fieldName); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/simpledb/metadata/metadata_mgr.go
+++ b/simpledb/metadata/metadata_mgr.go
@@ -13,7 +13,10 @@ type Manager struct {
 }
 
 func NewManager(isNew bool, tx *tx.Transaction) (*Manager, error) {
-	tableManager := NewTableManager(isNew, tx)
+	tableManager, err := NewTableManager(isNew, tx)
+	if err != nil {
+		return nil, err
+	}
 	viewManager, err := NewViewManager(isNew, tableManager, tx)
 	if err != nil {
 		return nil, err

--- a/simpledb/metadata/metadata_mgr_test.go
+++ b/simpledb/metadata/metadata_mgr_test.go
@@ -15,7 +15,10 @@ func TestMetadataManager(t *testing.T) {
 		t.Fatalf("failed to create simpledb: %v", err)
 	}
 	mdm := simpleDB.MetadataManager()
-	tx := simpleDB.NewTx()
+	tx, err := simpleDB.NewTx()
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
 
 	schema := record.NewSchema()
 	schema.AddIntField("A")
@@ -110,5 +113,7 @@ func TestMetadataManager(t *testing.T) {
 	fmt.Printf("V(indexB,A) = %d\n", ii.DistinctValues("A"))
 	fmt.Printf("V(indexB,B) = %d\n", ii.DistinctValues("B"))
 
-	tx.Commit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
 }

--- a/simpledb/metadata/metadata_mgr_test.go
+++ b/simpledb/metadata/metadata_mgr_test.go
@@ -27,6 +27,9 @@ func TestMetadataManager(t *testing.T) {
 		t.Fatalf("failed to create MyTable: %v", err)
 	}
 	layout, err := mdm.GetLayout("MyTable", tx)
+	if err != nil {
+		t.Fatalf("failed to get layout: %v", err)
+	}
 	size := layout.SlotSize()
 	schema2 := layout.Schema()
 	fmt.Printf("MyTable has slot size %d\n", size)
@@ -48,10 +51,16 @@ func TestMetadataManager(t *testing.T) {
 		t.Fatalf("failed to create table scan: %v", err)
 	}
 	for i := 0; i < 50; i++ {
-		tableScan.Insert()
+		if err := tableScan.Insert(); err != nil {
+			t.Fatalf("failed to insert: %v", err)
+		}
 		n := rand.Int31n(50)
-		tableScan.SetInt("A", n)
-		tableScan.SetString("B", fmt.Sprintf("rec%d", n))
+		if err := tableScan.SetInt("A", n); err != nil {
+			t.Fatalf("failed to set int: %v", err)
+		}
+		if err := tableScan.SetString("B", fmt.Sprintf("rec%d", n)); err != nil {
+			t.Fatalf("failed to set string: %v", err)
+		}
 	}
 	si, err := mdm.GetStatInfo("MyTable", layout, tx)
 	if err != nil {

--- a/simpledb/metadata/table_mgr.go
+++ b/simpledb/metadata/table_mgr.go
@@ -51,9 +51,15 @@ func (tm *TableManager) CreateTable(tableName string, schema *record.Schema, tx 
 	}
 	defer tableCatalog.Close()
 
-	tableCatalog.Insert()
-	tableCatalog.SetString(tableCatalogFieldTableName, tableName)
-	tableCatalog.SetInt(tableCatalogFieldSlotSize, layout.SlotSize())
+	if err := tableCatalog.Insert(); err != nil {
+		return err
+	}
+	if err := tableCatalog.SetString(tableCatalogFieldTableName, tableName); err != nil {
+		return err
+	}
+	if err := tableCatalog.SetInt(tableCatalogFieldSlotSize, layout.SlotSize()); err != nil {
+		return err
+	}
 
 	fieldCatalog, err := record.NewTableScan(tx, fieldCatalogTableName, tm.fieldCatalogLayout)
 	if err != nil {
@@ -62,12 +68,24 @@ func (tm *TableManager) CreateTable(tableName string, schema *record.Schema, tx 
 	defer fieldCatalog.Close()
 
 	for _, fieldName := range schema.Fields() {
-		fieldCatalog.Insert()
-		fieldCatalog.SetString(fieldCatalogFieldTableName, tableName)
-		fieldCatalog.SetString(fieldCatalogFieldFieldName, fieldName)
-		fieldCatalog.SetInt(fieldCatalogFieldType, int32(schema.Type(fieldName)))
-		fieldCatalog.SetInt(fieldCatalogFieldLength, schema.Length(fieldName))
-		fieldCatalog.SetInt(fieldCatalogFieldOffset, layout.Offset(fieldName))
+		if err := fieldCatalog.Insert(); err != nil {
+			return err
+		}
+		if err := fieldCatalog.SetString(fieldCatalogFieldTableName, tableName); err != nil {
+			return err
+		}
+		if err := fieldCatalog.SetString(fieldCatalogFieldFieldName, fieldName); err != nil {
+			return err
+		}
+		if err := fieldCatalog.SetInt(fieldCatalogFieldType, int32(schema.Type(fieldName))); err != nil {
+			return err
+		}
+		if err := fieldCatalog.SetInt(fieldCatalogFieldLength, schema.Length(fieldName)); err != nil {
+			return err
+		}
+		if err := fieldCatalog.SetInt(fieldCatalogFieldOffset, layout.Offset(fieldName)); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/simpledb/metadata/table_mgr.go
+++ b/simpledb/metadata/table_mgr.go
@@ -21,7 +21,7 @@ type TableManager struct {
 	fieldCatalogLayout *record.Layout
 }
 
-func NewTableManager(isNew bool, tx *tx.Transaction) *TableManager {
+func NewTableManager(isNew bool, tx *tx.Transaction) (*TableManager, error) {
 	tableCatalogSchema := record.NewSchema()
 	tableCatalogSchema.AddStringField(tableCatalogFieldTableName, MaxName)
 	tableCatalogSchema.AddIntField(tableCatalogFieldSlotSize)
@@ -37,10 +37,14 @@ func NewTableManager(isNew bool, tx *tx.Transaction) *TableManager {
 
 	tableManager := &TableManager{tableCatalogLayout, fieldCatalogLayout}
 	if isNew {
-		tableManager.CreateTable(tableCatalogTableName, tableCatalogSchema, tx)
-		tableManager.CreateTable(fieldCatalogTableName, fieldCatalogSchema, tx)
+		if err := tableManager.CreateTable(tableCatalogTableName, tableCatalogSchema, tx); err != nil {
+			return nil, err
+		}
+		if err := tableManager.CreateTable(fieldCatalogTableName, fieldCatalogSchema, tx); err != nil {
+			return nil, err
+		}
 	}
-	return tableManager
+	return tableManager, nil
 }
 
 func (tm *TableManager) CreateTable(tableName string, schema *record.Schema, tx *tx.Transaction) error {

--- a/simpledb/metadata/table_mgr_test.go
+++ b/simpledb/metadata/table_mgr_test.go
@@ -14,8 +14,14 @@ func TestTableManager(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create simpledb: %v", err)
 	}
-	transaction := simpleDB.NewTx()
-	tableManager := metadata.NewTableManager(true, transaction)
+	transaction, err := simpleDB.NewTx()
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
+	tableManager, err := metadata.NewTableManager(true, transaction)
+	if err != nil {
+		t.Fatalf("failed to create table manager: %v", err)
+	}
 
 	schema := record.NewSchema()
 	schema.AddIntField("A")
@@ -43,5 +49,7 @@ func TestTableManager(t *testing.T) {
 		}
 		fmt.Printf("%s: %s\n", fieldName, fieldType)
 	}
-	transaction.Commit()
+	if err := transaction.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
 }

--- a/simpledb/metadata/view_mgr.go
+++ b/simpledb/metadata/view_mgr.go
@@ -39,9 +39,15 @@ func (vm *ViewManager) CreateView(viewName string, viewDef string, tx *tx.Transa
 	}
 	defer ts.Close()
 
-	ts.Insert() // 書籍の方に記載されておらず罠
-	ts.SetString(viewCatalogFieldViewName, viewName)
-	ts.SetString(viewCatalogFieldViewDef, viewDef)
+	if err := ts.Insert(); err != nil { // 書籍の方に記載されておらず罠
+		return err
+	}
+	if err := ts.SetString(viewCatalogFieldViewName, viewName); err != nil {
+		return err
+	}
+	if err := ts.SetString(viewCatalogFieldViewDef, viewDef); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/simpledb/record/record_page.go
+++ b/simpledb/record/record_page.go
@@ -84,7 +84,9 @@ func (rp *RecordPage) InsertAfter(slot int32) (int32, error) {
 		return 0, err
 	}
 	if newSlot >= 0 {
-		rp.setFlag(newSlot, Used)
+		if err := rp.setFlag(newSlot, Used); err != nil {
+			return 0, err
+		}
 	}
 	return newSlot, nil
 }

--- a/simpledb/record/record_page.go
+++ b/simpledb/record/record_page.go
@@ -18,9 +18,11 @@ type RecordPage struct {
 	layout *Layout
 }
 
-func NewRecordPage(tx *tx.Transaction, blk file.BlockID, layout *Layout) *RecordPage {
-	tx.Pin(blk)
-	return &RecordPage{tx, blk, layout}
+func NewRecordPage(tx *tx.Transaction, blk file.BlockID, layout *Layout) (*RecordPage, error) {
+	if err := tx.Pin(blk); err != nil {
+		return nil, err
+	}
+	return &RecordPage{tx, blk, layout}, nil
 }
 
 func (rp *RecordPage) GetInt(slot int32, fieldName string) (int32, error) {

--- a/simpledb/record/record_test.go
+++ b/simpledb/record/record_test.go
@@ -13,9 +13,12 @@ func TestRecord(t *testing.T) {
 	t.Parallel()
 	db, err := server.NewSimpleDB(path.Join(t.TempDir(), "recordtest"), 400, 8)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
-	tx := db.NewTx()
+	tx, err := db.NewTx()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	schema := record.NewSchema()
 	schema.AddIntField("A")
@@ -34,7 +37,10 @@ func TestRecord(t *testing.T) {
 	if err := tx.Pin(blk); err != nil {
 		t.Fatalf("Failed to pin block: %v", err)
 	}
-	recordPage := record.NewRecordPage(tx, blk, layout)
+	recordPage, err := record.NewRecordPage(tx, blk, layout)
+	if err != nil {
+		t.Fatalf("Failed to create record page: %v", err)
+	}
 	if err = recordPage.Format(); err != nil {
 		t.Fatalf("Failed to format record page: %v", err)
 	}
@@ -110,5 +116,7 @@ func TestRecord(t *testing.T) {
 		}
 	}
 	tx.Unpin(blk)
-	tx.Commit()
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("Failed to commit transaction: %v", err)
+	}
 }

--- a/simpledb/record/record_test.go
+++ b/simpledb/record/record_test.go
@@ -31,10 +31,11 @@ func TestRecord(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to append block: %v", err)
 	}
-	tx.Pin(blk)
+	if err := tx.Pin(blk); err != nil {
+		t.Fatalf("Failed to pin block: %v", err)
+	}
 	recordPage := record.NewRecordPage(tx, blk, layout)
-	err = recordPage.Format()
-	if err != nil {
+	if err = recordPage.Format(); err != nil {
 		t.Fatalf("Failed to format record page: %v", err)
 	}
 

--- a/simpledb/record/table_scan_test.go
+++ b/simpledb/record/table_scan_test.go
@@ -30,10 +30,16 @@ func TestTableScan(t *testing.T) {
 		t.Fatalf("failed to create table scan: %v", err)
 	}
 	for i := 0; i < 50; i++ {
-		tableScan.Insert()
+		if err := tableScan.Insert(); err != nil {
+			t.Fatalf("failed to insert: %v", err)
+		}
 		n := rand.Int31n(50)
-		tableScan.SetInt("A", n)
-		tableScan.SetString("B", fmt.Sprintf("rec%d", n))
+		if err := tableScan.SetInt("A", n); err != nil {
+			t.Fatalf("failed to set int: %v", err)
+		}
+		if err := tableScan.SetString("B", fmt.Sprintf("rec%d", n)); err != nil {
+			t.Fatalf("failed to set string: %v", err)
+		}
 		fmt.Printf("inserting record into slot %s: {%d, %s}\n", tableScan.GetRID().String(), n, fmt.Sprintf("rec%d", n))
 	}
 	fmt.Println("Deleting these records, whose A-values are less than 25.")
@@ -55,7 +61,9 @@ func TestTableScan(t *testing.T) {
 		if a < 25 {
 			count++
 			fmt.Printf("deleting record from slot %s: {%d, %s}\n", tableScan.GetRID().String(), a, b)
-			tableScan.Delete()
+			if err := tableScan.Delete(); err != nil {
+				t.Fatalf("failed to delete: %v", err)
+			}
 		}
 		next, err = tableScan.Next()
 		if err != nil {

--- a/simpledb/record/table_scan_test.go
+++ b/simpledb/record/table_scan_test.go
@@ -15,7 +15,10 @@ func TestTableScan(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create simpledb: %v", err)
 	}
-	transaction := simpleDB.NewTx()
+	transaction, err := simpleDB.NewTx()
+	if err != nil {
+		t.Fatalf("failed to create transaction: %v", err)
+	}
 	schema := record.NewSchema()
 	schema.AddIntField("A")
 	schema.AddStringField("B", 9)
@@ -44,7 +47,9 @@ func TestTableScan(t *testing.T) {
 	}
 	fmt.Println("Deleting these records, whose A-values are less than 25.")
 	count := 0
-	tableScan.BeforeFirst()
+	if err := tableScan.BeforeFirst(); err != nil {
+		t.Fatalf("failed to before first: %v", err)
+	}
 	next, err := tableScan.Next()
 	if err != nil {
 		t.Fatalf("failed to get next: %v", err)
@@ -73,7 +78,9 @@ func TestTableScan(t *testing.T) {
 	fmt.Printf("%d values under 25 were deleted\n", count)
 
 	fmt.Println("Here are the remaining records.")
-	tableScan.BeforeFirst()
+	if err := tableScan.BeforeFirst(); err != nil {
+		t.Fatalf("failed to before first: %v", err)
+	}
 	next, err = tableScan.Next()
 	if err != nil {
 		t.Fatalf("failed to get next: %v", err)
@@ -94,5 +101,7 @@ func TestTableScan(t *testing.T) {
 		}
 	}
 	tableScan.Close()
-	transaction.Commit()
+	if err := transaction.Commit(); err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
 }

--- a/simpledb/tx/concurrency_test.go
+++ b/simpledb/tx/concurrency_test.go
@@ -30,10 +30,13 @@ func TestConcurrency(t *testing.T) {
 	go func() {
 		defer wg.Done()
 
-		txA := tx.New(fm, lm, bm)
+		txA, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
 		blk2 := file.NewBlockID("testfile", 2)
-		err := txA.Pin(blk1)
+		err = txA.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -45,7 +48,9 @@ func TestConcurrency(t *testing.T) {
 		_, err = txA.GetInt(blk1, 0)
 		if err != nil {
 			t.Logf("Tx A: %v, rollback", err)
-			txA.Rollback()
+			if err := txA.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx A: receive slock 1")
@@ -55,21 +60,28 @@ func TestConcurrency(t *testing.T) {
 		_, err = txA.GetInt(blk2, 0)
 		if err != nil {
 			t.Logf("Tx A: %v, rollback", err)
-			txA.Rollback()
+			if err := txA.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx A: receive slock 2")
-		txA.Commit()
+		if err := txA.Commit(); err != nil {
+			panic(err)
+		}
 		t.Log("Tx A: commit")
 	}()
 
 	go func() {
 		defer wg.Done()
 
-		txB := tx.New(fm, lm, bm)
+		txB, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
 		blk2 := file.NewBlockID("testfile", 2)
-		err := txB.Pin(blk1)
+		err = txB.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -81,7 +93,9 @@ func TestConcurrency(t *testing.T) {
 		err = txB.SetInt(blk2, 0, 0, false)
 		if err != nil {
 			t.Logf("Tx B: %v, rollback", err)
-			txB.Rollback()
+			if err := txB.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx B: receive xlock 2")
@@ -91,21 +105,28 @@ func TestConcurrency(t *testing.T) {
 		_, err = txB.GetInt(blk1, 0)
 		if err != nil {
 			t.Logf("Tx B: %v, rollback", err)
-			txB.Rollback()
+			if err := txB.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx B: receive slock 1")
-		txB.Commit()
+		if err := txB.Commit(); err != nil {
+			panic(err)
+		}
 		t.Log("Tx B: commit")
 	}()
 
 	go func() {
 		defer wg.Done()
 
-		txC := tx.New(fm, lm, bm)
+		txC, err := tx.New(fm, lm, bm)
+		if err != nil {
+			panic(err)
+		}
 		blk1 := file.NewBlockID("testfile", 1)
 		blk2 := file.NewBlockID("testfile", 2)
-		err := txC.Pin(blk1)
+		err = txC.Pin(blk1)
 		if err != nil {
 			panic(err)
 		}
@@ -119,7 +140,9 @@ func TestConcurrency(t *testing.T) {
 		err = txC.SetInt(blk1, 0, 0, false)
 		if err != nil {
 			t.Logf("Tx C: %v, rollback", err)
-			txC.Rollback()
+			if err := txC.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx C: receive xlock 1")
@@ -128,11 +151,15 @@ func TestConcurrency(t *testing.T) {
 		_, err = txC.GetInt(blk2, 0)
 		if err != nil {
 			t.Logf("Tx B: %v, rollback", err)
-			txC.Rollback()
+			if err := txC.Rollback(); err != nil {
+				panic(err)
+			}
 			return
 		}
 		t.Log("Tx C: receive slock 2")
-		txC.Commit()
+		if err := txC.Commit(); err != nil {
+			panic(err)
+		}
 		t.Log("Tx C: commit")
 	}()
 

--- a/simpledb/tx/recovery/recovery_test.go
+++ b/simpledb/tx/recovery/recovery_test.go
@@ -1,2 +1,1 @@
 package recovery_test
-

--- a/simpledb/tx/transaction.go
+++ b/simpledb/tx/transaction.go
@@ -130,13 +130,17 @@ func (tx *Transaction) SetString(blk file.BlockID, offset int32, val string, okT
 
 func (tx *Transaction) Size(filename string) (int32, error) {
 	dummyblk := file.NewBlockID(filename, endOfFile)
-	tx.concurMgr.SLock(dummyblk)
+	if err := tx.concurMgr.SLock(dummyblk); err != nil {
+		return 0, err
+	}
 	return tx.fm.Length(filename)
 }
 
 func (tx *Transaction) Append(filename string) (file.BlockID, error) {
 	dummyblk := file.NewBlockID(filename, endOfFile)
-	tx.concurMgr.XLock(dummyblk)
+	if err := tx.concurMgr.XLock(dummyblk); err != nil {
+		return file.BlockID{}, err
+	}
 	return tx.fm.Append(filename)
 }
 

--- a/simpledb/tx/transaction.go
+++ b/simpledb/tx/transaction.go
@@ -28,7 +28,7 @@ type Transaction struct {
 	mybuffers   *BufferList
 }
 
-func New(fileMgr *file.Manager, logMgr *log.Manager, bufferManager *buffer.Manager) *Transaction {
+func New(fileMgr *file.Manager, logMgr *log.Manager, bufferManager *buffer.Manager) (*Transaction, error) {
 	tx := &Transaction{
 		concurMgr: concurrency.New(),
 		fm:        fileMgr,
@@ -37,27 +37,43 @@ func New(fileMgr *file.Manager, logMgr *log.Manager, bufferManager *buffer.Manag
 		mybuffers: newBufferList(bufferManager),
 	}
 
-	tx.recoveryMgr = recovery.New(tx, tx.txnum, logMgr, bufferManager)
-	return tx
+	var err error
+	tx.recoveryMgr, err = recovery.New(tx, tx.txnum, logMgr, bufferManager)
+	if err != nil {
+		return nil, err
+	}
+	return tx, nil
 }
 
-func (tx *Transaction) Commit() {
-	tx.recoveryMgr.Commit()
+func (tx *Transaction) Commit() error {
+	if err := tx.recoveryMgr.Commit(); err != nil {
+		return err
+	}
 	tx.concurMgr.Release()
 	tx.mybuffers.unpinAll()
 	fmt.Printf("transaction %d committed\n", tx.txnum)
+
+	return nil
 }
 
-func (tx *Transaction) Rollback() {
-	tx.recoveryMgr.Rollback()
+func (tx *Transaction) Rollback() error {
+	if err := tx.recoveryMgr.Rollback(); err != nil {
+		return err
+	}
 	tx.concurMgr.Release()
 	tx.mybuffers.unpinAll()
 	fmt.Printf("transaction %d rolled back\n", tx.txnum)
+
+	return nil
 }
 
-func (tx *Transaction) Recover() {
+func (tx *Transaction) Recover() error {
 	tx.bm.FlushAll(tx.txnum)
-	tx.recoveryMgr.Recover()
+	if err := tx.recoveryMgr.Recover(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (tx *Transaction) Pin(blk file.BlockID) error {

--- a/simpledb/tx/transaction_test.go
+++ b/simpledb/tx/transaction_test.go
@@ -19,7 +19,10 @@ func TestTransaction(t *testing.T) {
 	lm := db.LogManager()
 	bm := db.BufferManager()
 
-	tx1 := tx.New(fm, lm, bm)
+	tx1, err := tx.New(fm, lm, bm)
+	if err != nil {
+		t.Fatal(err)
+	}
 	blk := file.NewBlockID("testfile", 1)
 	if err := tx1.Pin(blk); err != nil {
 		t.Fatal(err)
@@ -32,9 +35,14 @@ func TestTransaction(t *testing.T) {
 	if err := tx1.SetString(blk, 40, "one", false); err != nil {
 		t.Fatal(err)
 	}
-	tx1.Commit()
+	if err := tx1.Commit(); err != nil {
+		t.Fatal(err)
+	}
 
-	tx2 := tx.New(fm, lm, bm)
+	tx2, err := tx.New(fm, lm, bm)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := tx2.Pin(blk); err != nil {
 		t.Fatal(err)
 	}
@@ -62,9 +70,14 @@ func TestTransaction(t *testing.T) {
 	if err := tx2.SetString(blk, 40, newsval, true); err != nil {
 		t.Fatal(err)
 	}
-	tx2.Commit()
+	if err := tx2.Commit(); err != nil {
+		t.Fatal(err)
+	}
 
-	tx3 := tx.New(fm, lm, bm)
+	tx3, err := tx.New(fm, lm, bm)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = tx3.Pin(blk)
 	if err != nil {
 		t.Fatal(err)
@@ -96,9 +109,14 @@ func TestTransaction(t *testing.T) {
 		t.Fatalf("expected 9999, got %d", ival)
 	}
 	t.Logf("pre-rollback value at location 80 = %d\n", ival)
-	tx3.Rollback()
+	if err := tx3.Rollback(); err != nil {
+		t.Fatal(err)
+	}
 
-	tx4 := tx.New(fm, lm, bm)
+	tx4, err := tx.New(fm, lm, bm)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := tx4.Pin(blk); err != nil {
 		t.Fatal(err)
 	}
@@ -110,5 +128,7 @@ func TestTransaction(t *testing.T) {
 		t.Fatalf("expected 2, got %d", ival)
 	}
 	t.Logf("pre-recover value at location 80 = %d\n", ival)
-	tx4.Commit()
+	if err := tx4.Commit(); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/simpledb/tx/transaction_test.go
+++ b/simpledb/tx/transaction_test.go
@@ -21,25 +21,21 @@ func TestTransaction(t *testing.T) {
 
 	tx1 := tx.New(fm, lm, bm)
 	blk := file.NewBlockID("testfile", 1)
-	err = tx1.Pin(blk)
-	if err != nil {
+	if err := tx1.Pin(blk); err != nil {
 		t.Fatal(err)
 	}
 	// The block initially contains unknown bytes,
 	// so don't log those values here.
-	err = tx1.SetInt(blk, 80, 1, false)
-	if err != nil {
+	if err := tx1.SetInt(blk, 80, 1, false); err != nil {
 		t.Fatal(err)
 	}
-	err = tx1.SetString(blk, 40, "one", false)
-	if err != nil {
+	if err := tx1.SetString(blk, 40, "one", false); err != nil {
 		t.Fatal(err)
 	}
 	tx1.Commit()
 
 	tx2 := tx.New(fm, lm, bm)
-	err = tx2.Pin(blk)
-	if err != nil {
+	if err := tx2.Pin(blk); err != nil {
 		t.Fatal(err)
 	}
 	ival, err := tx2.GetInt(blk, 80)
@@ -60,8 +56,12 @@ func TestTransaction(t *testing.T) {
 	t.Logf("initial value at location 40 = %s\n", sval)
 	newival := ival + 1
 	newsval := sval + "!"
-	tx2.SetInt(blk, 80, newival, true)
-	tx2.SetString(blk, 40, newsval, true)
+	if err := tx2.SetInt(blk, 80, newival, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx2.SetString(blk, 40, newsval, true); err != nil {
+		t.Fatal(err)
+	}
 	tx2.Commit()
 
 	tx3 := tx.New(fm, lm, bm)
@@ -85,7 +85,9 @@ func TestTransaction(t *testing.T) {
 	}
 	t.Logf("initial value at location 80 = %d\n", ival)
 	t.Logf("initial value at location 40 = %s\n", sval)
-	tx3.SetInt(blk, 80, 9999, true)
+	if err := tx3.SetInt(blk, 80, 9999, true); err != nil {
+		t.Fatal(err)
+	}
 	ival, err = tx3.GetInt(blk, 80)
 	if err != nil {
 		t.Fatal(err)
@@ -97,8 +99,7 @@ func TestTransaction(t *testing.T) {
 	tx3.Rollback()
 
 	tx4 := tx.New(fm, lm, bm)
-	err = tx4.Pin(blk)
-	if err != nil {
+	if err := tx4.Pin(blk); err != nil {
 		t.Fatal(err)
 	}
 	ival, err = tx4.GetInt(blk, 80)


### PR DESCRIPTION
最低限のCIを追加

`errcheck` (returnされるerrorのチェック漏れ検知）で怒られまくってるので片っ端から修正

一応、 返り値の型を変えずに修正できるものが [fix errcheck 1](https://github.com/yokomotod/database-design-and-implementation-go/pull/9/commits/9447d091c7c7ad17d648b064788ce8ce3353545a)、返り値の型も変わって連鎖的に修正が必要なものが [fix errcheck 2](https://github.com/yokomotod/database-design-and-implementation-go/pull/9/commits/f913b03bd25c3fba2fe2832a6a1e2e5cdd57e4a9) とコミット分けて見ましたが、  
もはやあまり意味はない

diff大杉…やっぱり早いうちから入れとかないとだめだね（知ってた）