### PR TITLE
Fix BufferList.unpin

### DIFF
--- a/simpledb/buffer/buffer.go
+++ b/simpledb/buffer/buffer.go
@@ -44,6 +44,10 @@ func (b *Buffer) Pin() {
 }
 
 func (b *Buffer) Unpin() {
+	if b.pins <= 0 {
+		panic(fmt.Sprintf("unpin() called on unpinned buffer[block=%+v]=%dpins", b.block, b.pins))
+	}
+
 	b.pins--
 }
 

--- a/simpledb/tx/transaction.go
+++ b/simpledb/tx/transaction.go
@@ -209,7 +209,7 @@ func (b *BufferList) unpin(blk file.BlockID) {
 	b.bm.Unpin(buf)
 	for i, p := range b.pins {
 		if p == blk {
-			b.pins = slices.Delete(b.pins, i, i)
+			b.pins = slices.Delete(b.pins, i, i+1)
 			break
 		}
 	}


### PR DESCRIPTION
with unpin assertion:

```
=== RUN   TestTransaction
new transaction: 1
transaction 1 committed
new transaction: 2
    transaction_test.go:63: initial value at location 80 = 1
    transaction_test.go:64: initial value at location 40 = one
transaction 2 committed
new transaction: 3
    transaction_test.go:99: initial value at location 80 = 2
    transaction_test.go:100: initial value at location 40 = one!
    transaction_test.go:111: pre-rollback value at location 80 = 9999
--- FAIL: TestTransaction (0.00s)
panic: unpin() called on unpinned buffer[block={FileName:testfile Number:1}]=0pins [recovered]
```

---

(pick a commit from large and dirty #25 )
