### PR TITLE
IndexUpdatePlannerがBlockをオーバーフローする

### DIFF
--- a/simpledb/index/btree/page.go
+++ b/simpledb/index/btree/page.go
@@ -240,7 +240,7 @@ func (bp *BTreePage) makeDefaultRecord(blk file.BlockID, pos int32) error {
 func (bp *BTreePage) transferRecs(slot int32, dest *BTreePage) error {
 	destSlot := int32(0)
 	for {
-		nRecs, err := dest.GetNumRecs()
+		nRecs, err := bp.GetNumRecs()
 		if err != nil {
 			return err
 		}
@@ -259,7 +259,7 @@ func (bp *BTreePage) transferRecs(slot int32, dest *BTreePage) error {
 				return err
 			}
 		}
-		if err := dest.Delete(slot); err != nil {
+		if err := bp.Delete(slot); err != nil {
 			return err
 		}
 		destSlot++

--- a/simpledb/plan/index_update_planner.go
+++ b/simpledb/plan/index_update_planner.go
@@ -9,6 +9,8 @@ import (
 	"simpledb/tx"
 )
 
+var _ UpdatePlanner = (*IndexUpdatePlanner)(nil)
+
 type IndexUpdatePlanner struct {
 	mdm *metadata.Manager
 }
@@ -183,4 +185,26 @@ func (iup *IndexUpdatePlanner) ExecuteModify(data *parse.ModifyData, tx *tx.Tran
 	}
 	scan.Close()
 	return count, nil
+}
+
+func (iup *IndexUpdatePlanner) ExecuteCreateTable(data *parse.CreateTableData, tx *tx.Transaction) (int, error) {
+	tableName := data.TableName
+	schema := data.NewSchema
+	err := iup.mdm.CreateTable(tableName, schema, tx)
+	return 0, err
+}
+
+func (iup *IndexUpdatePlanner) ExecuteCreateView(data *parse.CreateViewData, tx *tx.Transaction) (int, error) {
+	viewName := data.ViewName
+	viewDef := data.ViewDef()
+	err := iup.mdm.CreateView(viewName, viewDef, tx)
+	return 0, err
+}
+
+func (iup *IndexUpdatePlanner) ExecuteCreateIndex(data *parse.CreateIndexData, tx *tx.Transaction) (int, error) {
+	indexName := data.IndexName
+	tableName := data.TableName
+	fieldName := data.FieldName
+	err := iup.mdm.CreateIndex(indexName, tableName, fieldName, tx)
+	return 0, err
 }

--- a/simpledb/plan/index_update_planner.go
+++ b/simpledb/plan/index_update_planner.go
@@ -67,7 +67,11 @@ func (iup *IndexUpdatePlanner) ExecuteInsert(data *parse.InsertData, tx *tx.Tran
 
 func (iup *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Transaction) (int, error) {
 	tableName := data.TableName
-	plan, err := NewTablePlan(tx, tableName, iup.mdm)
+	tablePlan, err := NewTablePlan(tx, tableName, iup.mdm)
+	if err != nil {
+		return 0, err
+	}
+	selectPlan, err := NewSelectPlan(tablePlan, data.Pred)
 	if err != nil {
 		return 0, err
 	}
@@ -75,7 +79,7 @@ func (iup *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Tran
 	if err != nil {
 		return 0, err
 	}
-	scan, err := plan.Open()
+	scan, err := selectPlan.Open()
 	if err != nil {
 		return 0, err
 	}

--- a/simpledb/server/server.go
+++ b/simpledb/server/server.go
@@ -66,7 +66,7 @@ func NewSimpleDBWithMetadata(dirname string) (*SimpleDB, error) {
 	}
 
 	queryPlanner := plan.NewBasicQueryPlanner(db.metadataManager)
-	updatePlanner := plan.NewBasicUpdatePlanner(db.metadataManager)
+	updatePlanner := plan.NewIndexUpdatePlanner(db.metadataManager)
 	db.planner = plan.NewPlanner(queryPlanner, updatePlanner)
 
 	if err := tx.Commit(); err != nil {


### PR DESCRIPTION
```
--- FAIL: TestGroupByPlan (0.01s)
panic: runtime error: slice bounds out of range [:404] with capacity 400 [recovered]
	panic: runtime error: slice bounds out of range [:404] with capacity 400

goroutine 35 [running]:
testing.tRunner.func1.2({0x702a80, 0xc0001672f0})
	/opt/hostedtoolcache/go/1.22.3/x64/src/testing/testing.go:1631 +0x3f7
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.22.3/x64/src/testing/testing.go:1634 +0x6b6
panic({0x702a80?, 0xc0001672f0?})
	/opt/hostedtoolcache/go/1.22.3/x64/src/runtime/panic.go:770 +0x132
simpledb/file.(*Page).GetInt(...)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/file/file.go:48
simpledb/tx/recovery.(*Manager).SetInt(0xc000196210, 0xc000120cc0, 0x190, 0xc0?)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/tx/recovery/recovery.go:77 +0x2e5
simpledb/tx.(*Transaction).SetInt(0xc00019[61](https://github.com/yokomotod/database-design-and-implementation-go/actions/runs/10898524763/job/30241922151?pr=30#step:4:62)e0, {{0xc0001b3b71, 0xf}, 0x0}, 0x190, 0x1e, 0x1)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/tx/transaction.go:114 +0x15b
simpledb/index/btree.(*BTreePage).setInt(0xc0001b68a0, 0x6, {0x7190d5, 0x7}, 0x1e)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/page.go:124 +0x17a
simpledb/index/btree.(*BTreePage).setVal(0xc0001b68a0, 0x6, {0x7190d5, 0x7}, 0xc000109530)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/page.go:139 +0x34d
simpledb/index/btree.(*BTreePage).copyRecord(0xc0001b68a0, 0x5, 0x6)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/page.go:177 +0x126
simpledb/index/btree.(*BTreePage).insert(0xc0001b68a0, 0x0)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/page.go:161 +0xe5
simpledb/index/btree.(*BTreePage).InsertLeaf(0xc0001b68a0, 0x0, 0xc000109410, 0xc0001b3688)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/page.go:317 +0x49
simpledb/index/btree.(*BTreeLeaf).Insert(0xc000121e80, 0xc0001b3688)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/leaf.go:136 +0x78d
simpledb/index/btree.(*BTreeIndex).Insert(0xc00014a550, 0xc000109410, 0xc0001b3688)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/index/btree/index.go:123 +0x94
simpledb/plan.(*IndexUpdatePlanner).ExecuteInsert(0xc00010a0d0, 0xc000121d40, 0xc0001961e0)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/plan/index_update_planner.go:58 +0x6f6
simpledb/plan.(*Planner).ExecuteUpdate(0xc0001444c0, {0xc0001[64](https://github.com/yokomotod/database-design-and-implementation-go/actions/runs/10898524763/job/30241922151?pr=30#step:4:65)640, 0x4d}, 0xc0001961e0)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/plan/planner.go:70 +0x222
simpledb/testlib.InsertTestData(0xc00014e9c0, 0xc00010cff0)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/testlib/helper.go:70 +0x69c
simpledb/plan_test.TestGroupByPlan(0xc00014e9c0)
	/home/runner/work/database-design-and-implementation-go/database-design-and-implementation-go/simpledb/plan/group_by_plan_test.go:17 +0x191
testing.tRunner(0xc00014e9c0, 0x742cc0)
	/opt/hostedtoolcache/go/1.22.3/x64/src/testing/testing.go:1[68](https://github.com/yokomotod/database-design-and-implementation-go/actions/runs/10898524763/job/30241922151?pr=30#step:4:69)9 +0x21f
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.22.3/x64/src/testing/testing.go:1742 +0x826
FAIL	simpledb/plan	0.026s
```