### PR TITLE
fix IndexUpdatePlanner.ExecuteDelete

### DIFF
--- a/simpledb/plan/index_update_planner.go
+++ b/simpledb/plan/index_update_planner.go
@@ -65,7 +65,11 @@ func (iup *IndexUpdatePlanner) ExecuteInsert(data *parse.InsertData, tx *tx.Tran
 
 func (iup *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Transaction) (int, error) {
 	tableName := data.TableName
-	plan, err := NewTablePlan(tx, tableName, iup.mdm)
+	tablePlan, err := NewTablePlan(tx, tableName, iup.mdm)
+	if err != nil {
+		return 0, err
+	}
+	selectPlan, err := NewSelectPlan(tablePlan, data.Pred)
 	if err != nil {
 		return 0, err
 	}
@@ -73,7 +77,7 @@ func (iup *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Tran
 	if err != nil {
 		return 0, err
 	}
-	scan, err := plan.Open()
+	scan, err := selectPlan.Open()
 	if err != nil {
 		return 0, err
 	}

--- a/simpledb/plan/index_update_planner.go
+++ b/simpledb/plan/index_update_planner.go
@@ -2,12 +2,13 @@ package plan
 
 import (
 	"errors"
-	"log"
 	"simpledb/metadata"
 	"simpledb/parse"
 	"simpledb/query"
 	"simpledb/tx"
 )
+
+var _ UpdatePlanner = (*IndexUpdatePlanner)(nil)
 
 type IndexUpdatePlanner struct {
 	mdm *metadata.Manager
@@ -17,16 +18,17 @@ func NewIndexUpdatePlanner(mdm *metadata.Manager) *IndexUpdatePlanner {
 	return &IndexUpdatePlanner{mdm}
 }
 
-func (iup *IndexUpdatePlanner) ExecuteInsert(data *parse.InsertData, tx *tx.Transaction) (int, error) {
-	tblname := data.TableName
-	plan, err := NewTablePlan(tx, tblname, iup.mdm)
+func (up *IndexUpdatePlanner) ExecuteInsert(data *parse.InsertData, tx *tx.Transaction) (int, error) {
+	tablePlan, err := NewTablePlan(tx, data.TableName, up.mdm)
 	if err != nil {
 		return 0, err
 	}
-	scan, err := plan.Open()
+	scan, err := tablePlan.Open()
 	if err != nil {
 		return 0, err
 	}
+	defer scan.Close()
+
 	updateScan, ok := scan.(query.UpdateScan)
 	if !ok {
 		return 0, errors.New("ExecuteInsert: plan is not a table plan")
@@ -34,64 +36,74 @@ func (iup *IndexUpdatePlanner) ExecuteInsert(data *parse.InsertData, tx *tx.Tran
 	if err := updateScan.Insert(); err != nil {
 		return 0, err
 	}
+
 	rid, err := updateScan.GetRID()
 	if err != nil {
 		return 0, err
 	}
-	indexes, err := iup.mdm.GetIndexInfo(tblname, tx)
+	indexes, err := up.mdm.GetIndexInfo(data.TableName, tx)
 	if err != nil {
 		return 0, err
 	}
-	for i, fieldName := range data.Fields {
+
+	for i, field := range data.Fields {
 		val := data.Values[i]
-		log.Printf("Modify field %s to value %v", fieldName, val)
-		if err := updateScan.SetVal(fieldName, val); err != nil {
+		if err := updateScan.SetVal(field, val); err != nil {
 			return 0, err
 		}
-		if ii, ok := indexes[fieldName]; ok {
-			idx, err := ii.Open()
-			if err != nil {
-				return 0, err
-			}
-			if err := idx.Insert(val, rid); err != nil {
-				return 0, err
-			}
-			idx.Close()
+
+		ii, ok := indexes[field]
+		if !ok {
+			continue
 		}
+
+		idx, err := ii.Open()
+		if err != nil {
+			return 0, err
+		}
+		if err := idx.Insert(val, rid); err != nil {
+			return 0, err
+		}
+		idx.Close()
 	}
-	scan.Close()
 	return 1, nil
 }
 
-func (iup *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Transaction) (int, error) {
+func (up *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Transaction) (int, error) {
 	tableName := data.TableName
-	tablePlan, err := NewTablePlan(tx, tableName, iup.mdm)
+	tablePlan, err := NewTablePlan(tx, tableName, up.mdm)
 	if err != nil {
 		return 0, err
 	}
+
 	selectPlan, err := NewSelectPlan(tablePlan, data.Pred)
 	if err != nil {
 		return 0, err
 	}
-	indexes, err := iup.mdm.GetIndexInfo(tableName, tx)
+
+	indexes, err := up.mdm.GetIndexInfo(tableName, tx)
 	if err != nil {
 		return 0, err
 	}
+
 	scan, err := selectPlan.Open()
 	if err != nil {
 		return 0, err
 	}
+	defer scan.Close()
+
 	updateScan, ok := scan.(query.UpdateScan)
 	if !ok {
 		return 0, errors.New("ExecuteDelete: plan is not a table plan")
 	}
 	count := 0
 	for {
-		if ok, err := scan.Next(); err != nil {
+		if hasNext, err := scan.Next(); err != nil {
 			return 0, err
-		} else if !ok {
+		} else if !hasNext {
 			break
 		}
+
 		rid, err := updateScan.GetRID()
 		if err != nil {
 			return 0, err
@@ -110,81 +122,111 @@ func (iup *IndexUpdatePlanner) ExecuteDelete(data *parse.DeleteData, tx *tx.Tran
 			}
 			idx.Close()
 		}
+
 		if err := updateScan.Delete(); err != nil {
 			return 0, err
 		}
 		count++
 	}
-	scan.Close()
 	return count, nil
 }
 
-func (iup *IndexUpdatePlanner) ExecuteModify(data *parse.ModifyData, tx *tx.Transaction) (int, error) {
-	tableName := data.TableName
-	fieldName := data.TargetField
-	tablePlan, err := NewTablePlan(tx, tableName, iup.mdm)
+func (up *IndexUpdatePlanner) ExecuteModify(data *parse.ModifyData, tx *tx.Transaction) (int, error) {
+	tablePlan, err := NewTablePlan(tx, data.TableName, up.mdm)
 	if err != nil {
 		return 0, err
 	}
-	plan, err := NewSelectPlan(tablePlan, data.Pred)
+
+	selectPlan, err := NewSelectPlan(tablePlan, data.Pred)
 	if err != nil {
 		return 0, err
 	}
-	indexInfoMap, err := iup.mdm.GetIndexInfo(tableName, tx)
+
+	indexInfoMap, err := up.mdm.GetIndexInfo(data.TableName, tx)
 	if err != nil {
 		return 0, err
 	}
-	indexInfo, ok := indexInfoMap[fieldName]
 	var idx query.Index
-	if ok {
+	if indexInfo, ok := indexInfoMap[data.TargetField]; ok {
 		idx, err = indexInfo.Open()
 		if err != nil {
 			return 0, err
 		}
 	}
-	scan, err := plan.Open()
+
+	scan, err := selectPlan.Open()
 	if err != nil {
 		return 0, err
 	}
+	defer scan.Close()
+
 	updateScan, ok := scan.(query.UpdateScan)
 	if !ok {
 		return 0, errors.New("ExecuteModify: plan is not a table plan")
 	}
 	count := 0
 	for {
-		if ok, err := scan.Next(); err != nil {
+		if hasNext, err := scan.Next(); err != nil {
 			return 0, err
-		} else if !ok {
+		} else if !hasNext {
 			break
 		}
+
 		newVal, err := data.NewValue.Evaluate(scan)
 		if err != nil {
 			return 0, err
 		}
-		oldVal, err := scan.GetVal(fieldName)
+		oldVal, err := scan.GetVal(data.TargetField)
 		if err != nil {
 			return 0, err
 		}
 		if err := updateScan.SetVal(data.TargetField, newVal); err != nil {
 			return 0, err
 		}
-		if idx != nil {
-			rid, err := updateScan.GetRID()
-			if err != nil {
-				return 0, err
-			}
-			if err := idx.Delete(oldVal, rid); err != nil {
-				return 0, err
-			}
-			if err := idx.Insert(newVal, rid); err != nil {
-				return 0, err
-			}
-		}
+
 		count++
+
+		if idx == nil {
+			continue
+		}
+
+		rid, err := updateScan.GetRID()
+		if err != nil {
+			return 0, err
+		}
+		if err := idx.Delete(oldVal, rid); err != nil {
+			return 0, err
+		}
+		if err := idx.Insert(newVal, rid); err != nil {
+			return 0, err
+		}
 	}
+
 	if idx != nil {
 		idx.Close()
 	}
-	scan.Close()
+
 	return count, nil
+}
+
+func (up *IndexUpdatePlanner) ExecuteCreateTable(data *parse.CreateTableData, tx *tx.Transaction) (int, error) {
+	tableName := data.TableName
+	schema := data.NewSchema
+	err := up.mdm.CreateTable(tableName, schema, tx)
+	return 0, err
+}
+
+func (up *IndexUpdatePlanner) ExecuteCreateView(data *parse.CreateViewData, tx *tx.Transaction) (int, error) {
+	viewName := data.ViewName
+	viewDef := data.ViewDef()
+	err := up.mdm.CreateView(viewName, viewDef, tx)
+	return 0, err
+}
+
+func (up *IndexUpdatePlanner) ExecuteCreateIndex(data *parse.CreateIndexData, tx *tx.Transaction) (int, error) {
+	indexName := data.IndexName
+	tableName := data.TableName
+	fieldName := data.FieldName
+	err := up.mdm.CreateIndex(indexName, tableName, fieldName, tx)
+	return 0, err
 }

--- a/simpledb/plan/planner_test.go
+++ b/simpledb/plan/planner_test.go
@@ -3,128 +3,142 @@ package plan_test
 import (
 	"path"
 	"simpledb/server"
-	"sort"
 	"testing"
 )
 
-func TestStudent(t *testing.T) {
-	simpleDB, err := server.NewSimpleDBWithMetadata(path.Join(t.TempDir(), "studentdb"))
-	if err != nil {
-		t.Fatalf("failed to create simpledb: %v", err)
-	}
-	tx, err := simpleDB.NewTx()
-	if err != nil {
-		t.Fatalf("failed to create tx: %v", err)
-	}
-
-	planner := simpleDB.Planner()
-
-	_, err = planner.ExecuteUpdate("create table student (sid int, sname varchar(10), majorid int, gradyear int)", tx)
-	if err != nil {
-		t.Fatalf("failed to create table: %v", err)
-	}
-	t.Logf("created table student")
-
-	cnt, err := planner.ExecuteUpdate("insert into student(sid, sname, majorid) values (1, 'joe', 10, 2021)", tx)
-	if err != nil {
-		t.Fatalf("failed to insert into table: %v", err)
-	}
-	t.Logf("insert into student: %d", cnt)
-	if cnt != 1 {
-		t.Errorf("inserted count: want: 1, got: %d", cnt)
+func TestPlannerStudent(t *testing.T) {
+	cases := []struct {
+		name     string
+		useBasic bool
+	}{
+		{"Basic", true},
+		{"Indexed", false},
 	}
 
-	cnt, err = planner.ExecuteUpdate("insert into student(sid, sname, majorid) values (2, 'xxx', 20, 2020)", tx)
-	if err != nil {
-		t.Fatalf("failed to insert into table: %v", err)
-	}
-	t.Logf("insert into student: %d", cnt)
-	if cnt != 1 {
-		t.Errorf("inserted count: want: 1, got: %d", cnt)
-	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var simpleDB *server.SimpleDB
+			var err error
+			if c.useBasic {
+				simpleDB, err = server.NewSimpleDBWithMetadata(path.Join(t.TempDir(), "studentdb"))
+			} else {
+				simpleDB, err = server.NewIndexedSimpleDB(path.Join(t.TempDir(), "studentdb"))
+			}
+			if err != nil {
+				t.Fatalf("failed to create simpledb: %v", err)
+			}
+			tx, err := simpleDB.NewTx()
+			if err != nil {
+				t.Fatalf("failed to create tx: %v", err)
+			}
 
-	cnt, err = planner.ExecuteUpdate("update student set sname = 'amy' where sid = 2", tx)
-	if err != nil {
-		t.Fatalf("failed to update table: %v", err)
-	}
-	if cnt != 1 {
-		t.Errorf("deleted count: want: 1, got: %d", cnt)
-	}
+			planner := simpleDB.Planner()
 
-	// this is to be deleted by the following statements
-	_, err = planner.ExecuteUpdate("insert into student(sid, sname, majorid) values (3, 'tbd', 20, 2020)", tx)
-	if err != nil {
-		t.Fatalf("failed to insert into table: %v", err)
-	}
+			_, err = planner.ExecuteUpdate("create table student (sid int, sname varchar(10), majorid int, gradyear int)", tx)
+			if err != nil {
+				t.Fatalf("failed to create table: %v", err)
+			}
+			t.Logf("created table student")
 
-	cnt, err = planner.ExecuteUpdate("delete from student where sid = 99", tx)
-	if err != nil {
-		t.Fatalf("failed to delete from table: %v", err)
-	}
-	if cnt != 0 {
-		t.Errorf("deleted count: want: 0, got: %d", cnt)
-	}
+			cnt, err := planner.ExecuteUpdate("insert into student(sid, sname, majorid) values (1, 'joe', 10, 2021)", tx)
+			if err != nil {
+				t.Fatalf("failed to insert into table: %v", err)
+			}
+			t.Logf("insert into student: %d", cnt)
+			if cnt != 1 {
+				t.Errorf("inserted count: want: 1, got: %d", cnt)
+			}
 
-	cnt, err = planner.ExecuteUpdate("delete from student where sid = 3", tx)
-	if err != nil {
-		t.Fatalf("failed to delete from table: %v", err)
-	}
-	if cnt != 1 {
-		t.Errorf("deleted count: want: 1, got: %d", cnt)
-	}
+			cnt, err = planner.ExecuteUpdate("insert into student(sid, sname, majorid) values (2, 'xxx', 20, 2020)", tx)
+			if err != nil {
+				t.Fatalf("failed to insert into table: %v", err)
+			}
+			t.Logf("insert into student: %d", cnt)
+			if cnt != 1 {
+				t.Errorf("inserted count: want: 1, got: %d", cnt)
+			}
 
-	plan, err := planner.CreateQueryPlan("select sid, sname from student", tx)
-	if err != nil {
-		t.Fatalf("failed to create query plan: %v", err)
-	}
+			cnt, err = planner.ExecuteUpdate("update student set sname = 'amy' where sid = 2", tx)
+			if err != nil {
+				t.Fatalf("failed to update table: %v", err)
+			}
+			if cnt != 1 {
+				t.Errorf("updated count: want: 1, got: %d", cnt)
+			}
 
-	sc, err := plan.Open()
-	if err != nil {
-		t.Fatalf("failed to open scan: %v", err)
-	}
+			// this is to be deleted by the following statements
+			_, err = planner.ExecuteUpdate("insert into student(sid, sname, majorid) values (3, 'tbd', 20, 2020)", tx)
+			if err != nil {
+				t.Fatalf("failed to insert into table: %v", err)
+			}
 
-	type student struct {
-		sid   int32
-		sname string
-	}
-	want := []student{
-		{1, "joe"},
-		{2, "amy"},
-	}
-	got := make([]student, 0, 2)
+			cnt, err = planner.ExecuteUpdate("delete from student where sid = 99", tx)
+			if err != nil {
+				t.Fatalf("failed to delete from table: %v", err)
+			}
+			if cnt != 0 {
+				t.Errorf("deleted count: want: 0, got: %d", cnt)
+			}
 
-	for {
-		next, err := sc.Next()
-		if err != nil {
-			t.Fatalf("failed to get next: %v", err)
-		}
-		if !next {
-			break
-		}
+			cnt, err = planner.ExecuteUpdate("delete from student where sid = 3", tx)
+			if err != nil {
+				t.Fatalf("failed to delete from table: %v", err)
+			}
+			if cnt != 1 {
+				t.Errorf("deleted count: want: 1, got: %d", cnt)
+			}
 
-		sid, err := sc.GetInt("sid")
-		if err != nil {
-			t.Fatalf("failed to get int: %v", err)
-		}
-		sname, err := sc.GetString("sname")
-		if err != nil {
-			t.Fatalf("failed to get string: %v", err)
-		}
-		got = append(got, student{sid, sname})
-		t.Logf("sid: %d, sname: %s", sid, sname)
-	}
+			plan, err := planner.CreateQueryPlan("select sid, sname from student", tx)
+			if err != nil {
+				t.Fatalf("failed to create query plan: %v", err)
+			}
 
-	sort.SliceStable(got, func(i, j int) bool {
-		return got[i].sid < got[j].sid
-	})
-	for i, s := range got {
-		if s != want[i] {
-			t.Errorf("want: %v, got: %v", want[i], got[i])
-		}
-	}
-	sc.Close()
-	err = tx.Commit()
-	if err != nil {
-		t.Fatalf("failed to commit: %v", err)
+			sc, err := plan.Open()
+			if err != nil {
+				t.Fatalf("failed to open scan: %v", err)
+			}
+
+			type student struct {
+				sid   int32
+				sname string
+			}
+			want := []student{
+				{1, "joe"},
+				{2, "amy"},
+			}
+			got := make([]student, 0, 2)
+
+			for {
+				next, err := sc.Next()
+				if err != nil {
+					t.Fatalf("failed to get next: %v", err)
+				}
+				if !next {
+					break
+				}
+
+				sid, err := sc.GetInt("sid")
+				if err != nil {
+					t.Fatalf("failed to get int: %v", err)
+				}
+				sname, err := sc.GetString("sname")
+				if err != nil {
+					t.Fatalf("failed to get string: %v", err)
+				}
+				got = append(got, student{sid, sname})
+				t.Logf("sid: %d, sname: %s", sid, sname)
+			}
+
+			for i, s := range got {
+				if s != want[i] {
+					t.Errorf("want: %v, got: %v", want[i], got[i])
+				}
+			}
+			sc.Close()
+			err = tx.Commit()
+			if err != nil {
+				t.Fatalf("failed to commit: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
https://github.com/yokomotod/database-design-and-implementation-go/pull/30#issuecomment-2356200080 の問題の修正

コミットごとに見てもらえると

* [fix IndexUpdatePlanner.ExecuteDelete](https://github.com/yokomotod/database-design-and-implementation-go/pull/32/commits/fe573a77d3090e9c28a6932425d19a97dc27b710): バグ修正。SelectScanがかかってなかった
* [fix minify diff between basic and index update planner](https://github.com/yokomotod/database-design-and-implementation-go/pull/32/commits/ed14a728b11f92703215df24cc3aa5760f3db341): `IndexUpdatePlanner` は「 `BasicUpdatePlanner` の処理 + インデックスの更新」なので、共通処理の部分の見た目を揃えた
* [test IndexUpdatePlanner](https://github.com/yokomotod/database-design-and-implementation-go/pull/32/commits/39e657215f530da72152f02e3772fd37c06b7203): testされるようにした